### PR TITLE
[BugFix] 修复配置文件调用错误

### DIFF
--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/__init__.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/__init__.py
@@ -166,13 +166,13 @@ class CQHTTPAdapter(WebSocketAdapter):
 
         start_time = time.time()
         while not self.bot.should_exit.is_set():
-            if time.time() - start_time > self.config.api_timeout:
+            if time.time() - start_time > self.config['api_timeout']:
                 break
             async with self._api_response_cond:
                 try:
                     await asyncio.wait_for(
                         self._api_response_cond.wait(),
-                        timeout=start_time + self.config.api_timeout - time.time(),
+                        timeout=start_time + self.config['api_timeout'] - time.time(),
                     )
                 except asyncio.TimeoutError:
                     break


### PR DESCRIPTION
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/79645438/186661107-6530ec50-f68e-4b12-87ba-14a543aa51e7.png">
如图 发生在`bot reload`命令后
`bot reload` 命令内容如下
<img width="581" alt="image" src="https://user-images.githubusercontent.com/79645438/186661277-6994c2ab-e557-4d89-b32c-4c3e24897fd4.png">
我的想法是改一下调用
这样解决问题最为快速