### PR TITLE
[mirai]bug修复：修改部分群事件的operator参数类型为可选类型

### DIFF
--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import create_model
 
@@ -127,7 +127,7 @@ class GroupRecallEvent(GroupNoticeEvent):
     messageId: int
     time: int
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupNameChangeEvent(GroupNoticeEvent):
@@ -137,7 +137,7 @@ class GroupNameChangeEvent(GroupNoticeEvent):
     origin: str
     current: str
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupEntranceAnnouncementChangeEvent(GroupNoticeEvent):
@@ -147,7 +147,7 @@ class GroupEntranceAnnouncementChangeEvent(GroupNoticeEvent):
     origin: str
     current: str
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupMuteAllEvent(GroupNoticeEvent):
@@ -157,7 +157,7 @@ class GroupMuteAllEvent(GroupNoticeEvent):
     origin: bool
     current: bool
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupAllowAnonymousChatEvent(GroupNoticeEvent):
@@ -167,7 +167,7 @@ class GroupAllowAnonymousChatEvent(GroupNoticeEvent):
     origin: bool
     current: bool
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupAllowConfessTalkEvent(GroupNoticeEvent):
@@ -187,7 +187,7 @@ class GroupAllowMemberInviteEvent(GroupNoticeEvent):
     origin: bool
     current: bool
     group: GroupInfo
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class GroupMemberEvent(GroupEvent):
@@ -206,7 +206,7 @@ class MemberLeaveEventKick(GroupMemberEvent):
     """成员被踢出群（该成员不是Bot）"""
 
     type: Literal["MemberLeaveEventKick"]
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class MemberLeaveEventQuit(GroupMemberEvent):
@@ -244,14 +244,14 @@ class MemberMuteEvent(GroupMemberEvent):
 
     type: Literal["MemberMuteEvent"]
     durationSeconds: int
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class MemberUnmuteEvent(GroupMemberEvent):
     """群成员被取消禁言事件（该成员不是Bot）"""
 
     type: Literal["MemberUnmuteEvent"]
-    operator: GroupMemberInfo
+    operator: Optional[GroupMemberInfo]
 
 
 class MemberHonorChangeEvent(GroupMemberEvent):


### PR DESCRIPTION
## bug 信息
根据 mirai 的 [api 文档（事件类型）](https://docs.mirai.mamoe.net/mirai-api-http/api/EventType)，所有操作人可能是bot自己的群事件，其operator参数均为可选类型。例如[群消息撤回](https://docs.mirai.mamoe.net/mirai-api-http/api/EventType.html#%E7%BE%A4%E6%B6%88%E6%81%AF%E6%92%A4%E5%9B%9E)事件的参数为：
| 参数名 | 类型 | 说明 |
| :----: | :----: | :----: |
| operator | Object? | 撤回消息的操作人，当null时为bot操作 |
| ... | ... | ... |

但 alicebot 的 mirai 适配器的相应实现为：
```python
class GroupRecallEvent(GroupNoticeEvent):
    """群消息撤回"""
    operator: GroupMemberInfo
    # ...: ...
```

当 mirai 适配器接收到 operator 参数为 None 的群事件时，终端会提示错误信息：
```
alicebot.log:error_or_exception:15 - Run adapter MiraiAdapter failed: ValidationError(model='MemberMuteEvent', errors=[{'loc': ('operator',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}])
```
即 operator 不应为 None 的错误信息。


## bug 复现
### 复现原理
为复现 bug，先让 mirai 适配器调用全员禁言的 api。由于该行为是 bot 主动发起的，mirai 传回的全员禁言事件的 operator 参数就为 None。而 GroupMuteAllEvent 的 operator 参数类型不为可选类型，于是 pydantic 就会报错。

### 测试环境
python 版本：Python 3.11.1
alicebot 版本：0.6.1
alicebot-adapter-mirai 版本: 0.6.0.post1

### 测试流程
测试插件的代码如下：
```python
from alicebot import Plugin


class Test(Plugin):
    async def handle(self) -> None:
        await self.event.adapter.call_api(command="muteAll", target=self.event.sender.group.id)

    async def rule(self) -> bool:
        if self.event.type != "GroupMessage":
            return False
            
        return self.event.message.get_plain_text() == '.test'
```

运行插件后，在测试的群聊中输入“.test”。终端会输出以下结果：
```
2023-03-17 01:32:06.921 | ERROR | alicebot.log:error_or_exception:15 - Run adapter MiraiAdapter failed: ValidationError(model='GroupMuteAllEvent', errors=[{'loc': ('operator',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'}])
```


## 修复方案
将这些出现问题的群事件类型的 operator 参数修改为可选类型即可。以群消息撤回为例，原来的代码为：
```python
class GroupRecallEvent(GroupNoticeEvent):
    """群消息撤回"""
    operator: GroupMemberInfo
    # ...: ...
```

修改后的代码为：
```python
class GroupRecallEvent(GroupNoticeEvent):
    """群消息撤回"""
    operator: Optional[GroupMemberInfo]
    # ...: ...
```

涉及的事件类型如下：
| 事件类型 | Python 类型名 |
| :----: | :----: |
| 群消息撤回 | GroupRecallEvent |
| 某个群名改变 | GroupNameChangeEvent |
| 某群入群公告改变 | GroupEntranceAnnouncementChangeEvent |
| 全员禁言 | GroupMuteAllEvent |
| 匿名聊天 | GroupAllowAnonymousChatEvent |
| 允许群员邀请好友加群 | GroupAllowMemberInviteEvent |
| 成员被踢出群（该成员不是Bot） | MemberLeaveEventKick |
| 群成员被禁言事件（该成员不是Bot） | MemberMuteEvent |
| 群成员被取消禁言事件 | MemberUnmuteEvent |

该 PR 将以上事件类型的 operator 参数均修改为了可选类型。